### PR TITLE
✏ fix: update deprecated OpenJDK to Amazon Corretto

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17
+FROM amazoncorretto:17
 ARG JAR_FILE=../build/libs/*.jar
 COPY ${JAR_FILE} app.jar
 ENTRYPOINT ["java", "-jar", "/app.jar"]


### PR DESCRIPTION
현재 사용 중인 openjdk:17의 버그를 수정한 amazon Corretto 17 이미지를 사용하도록 업데이트하였습니다.
openjdk 도커 이미지 사용 중단 권고는 https://hub.docker.com/_/openjdk 참조하시면 됩니다.